### PR TITLE
miss cast in IMU.cpp

### DIFF
--- a/examples/Basics/SH200I/SH200I.ino
+++ b/examples/Basics/SH200I/SH200I.ino
@@ -1,12 +1,12 @@
 #include <M5StickC.h>
 
-int16_t accX = 0;
-int16_t accY = 0;
-int16_t accZ = 0;
+float accX = 0.0F;
+float accY = 0.0F;
+float accZ = 0.0F;
 
-int16_t gyroX = 0;
-int16_t gyroY = 0;
-int16_t gyroZ = 0;
+float gyroX = 0.0F;
+float gyroY = 0.0F;
+float gyroZ = 0.0F;
 
 void setup() {
   // put your setup code here, to run once:
@@ -21,9 +21,7 @@ void setup() {
   M5.Lcd.println("  X       Y       Z");
 }
 
-
-
-int16_t temp = 0;
+float temp = 0;
 /*****************************************
 M5.IMU.getGyroData(&gyroX,&gyroY,&gyroZ);
 M5.IMU.getAccelData(&accX,&accY,&accZ);
@@ -31,20 +29,19 @@ M5.IMU.getTempData(&temp);
 *****************************************/
 void loop() {
   // put your main code here, to run repeatedly:
-  M5.IMU.getGyroAdc(&gyroX,&gyroY,&gyroZ);
-  M5.IMU.getAccelAdc(&accX,&accY,&accZ);
-  M5.IMU.getTempAdc(&temp);
+  M5.IMU.getGyroData(&gyroX,&gyroY,&gyroZ);
+  M5.IMU.getAccelData(&accX,&accY,&accZ);
+  M5.IMU.getTempData(&temp);
   
   M5.Lcd.setCursor(0, 30);
-  M5.Lcd.printf("%.2f   %.2f   %.2f      ", ((float) gyroX) * M5.IMU.gRes, ((float) gyroY) * M5.IMU.gRes,((float) gyroZ) * M5.IMU.gRes);
+  M5.Lcd.printf("%6.2f  %6.2f  %6.2f      ", gyroX, gyroY, gyroZ);
   M5.Lcd.setCursor(140, 30);
-  M5.Lcd.print("mg");
-  M5.Lcd.setCursor(0, 45);
-  M5.Lcd.printf("%.2f   %.2f   %.2f      ",((float) accX) * M5.IMU.aRes,((float) accY) * M5.IMU.aRes, ((float) accZ) * M5.IMU.aRes);
-  M5.Lcd.setCursor(140, 45);
   M5.Lcd.print("o/s");
+  M5.Lcd.setCursor(0, 45);
+  M5.Lcd.printf(" %5.2f   %5.2f   %5.2f   ", accX, accY, accZ);
+  M5.Lcd.setCursor(140, 45);
+  M5.Lcd.print("G");
   M5.Lcd.setCursor(0, 60);
-  M5.Lcd.printf("Temperature : %.2f C",((float) temp) / 333.87 + 21.0);
+  M5.Lcd.printf("Temperature : %.2f C", temp);
   delay(1000);
-
 }

--- a/src/IMU.cpp
+++ b/src/IMU.cpp
@@ -273,5 +273,5 @@ void IMU::getTempData(float *t){
   uint8_t buf[2];  
   I2C_Read_NBytes(SH200I_ADDRESS,SH200I_OUTPUT_TEMP,2,buf);
 
-  *t=(float)((buf[1]<<8)|buf[0]) / 333.87 + 21.0;
+  *t=(int16_t)((buf[1]<<8)|buf[0]) / 333.87 + 21.0;
 }

--- a/src/IMU.cpp
+++ b/src/IMU.cpp
@@ -216,9 +216,9 @@ void IMU::getAccelAdc(int16_t* ax, int16_t* ay, int16_t* az){
    uint8_t buf[6];  
    I2C_Read_NBytes(SH200I_ADDRESS,SH200I_OUTPUT_ACC,6,buf);
 	
-   *ax=((int16_t)buf[1]<<8)|buf[0];  
-   *ay=((int16_t)buf[3]<<8)|buf[2];  
-   *az=((int16_t)buf[5]<<8)|buf[4];
+   *ax=(int16_t)((buf[1]<<8)|buf[0]);  
+   *ay=(int16_t)((buf[3]<<8)|buf[2]);  
+   *az=(int16_t)((buf[5]<<8)|buf[4]);
 
    //getAres();
 }
@@ -228,9 +228,9 @@ void IMU::getAccelData(float* ax, float* ay, float* az){
    uint8_t buf[6];  
    I2C_Read_NBytes(SH200I_ADDRESS,SH200I_OUTPUT_ACC,6,buf);
 	
-   *ax=(((int16_t)buf[1]<<8)|buf[0]) * aRes;  
-   *ay=(((int16_t)buf[3]<<8)|buf[2]) * aRes;  
-   *az=(((int16_t)buf[5]<<8)|buf[4]) * aRes;
+   *ax=(int16_t)((buf[1]<<8)|buf[0]) * aRes;  
+   *ay=(int16_t)((buf[3]<<8)|buf[2]) * aRes;  
+   *az=(int16_t)((buf[5]<<8)|buf[4]) * aRes;
 
    //getAres();
 }
@@ -239,9 +239,9 @@ void IMU::getGyroAdc(int16_t* gx, int16_t* gy, int16_t* gz){
    uint8_t buf[6];  
    I2C_Read_NBytes(SH200I_ADDRESS,SH200I_OUTPUT_GYRO,6,buf);
 	
-   *gx=((uint16_t)buf[1]<<8)|buf[0];  
-   *gy=((uint16_t)buf[3]<<8)|buf[2];  
-   *gz=((uint16_t)buf[5]<<8)|buf[4];
+   *gx=(int16_t)((buf[1]<<8)|buf[0]);  
+   *gy=(int16_t)((buf[3]<<8)|buf[2]);  
+   *gz=(int16_t)((buf[5]<<8)|buf[4]);
 
    //getGres();
 
@@ -252,9 +252,9 @@ void IMU::getGyroData(float* gx, float* gy, float* gz){
    uint8_t buf[6];  
    I2C_Read_NBytes(SH200I_ADDRESS,SH200I_OUTPUT_GYRO,6,buf);
 	
-   *gx=(((uint16_t)buf[1]<<8)|buf[0])   * gRes;  
-   *gy=(((uint16_t)buf[3]<<8)|buf[2])   * gRes;  
-   *gz=(((uint16_t)buf[5]<<8)|buf[4])   * gRes;
+   *gx=(int16_t)((buf[1]<<8)|buf[0]) * gRes;  
+   *gy=(int16_t)((buf[3]<<8)|buf[2]) * gRes;  
+   *gz=(int16_t)((buf[5]<<8)|buf[4]) * gRes;
 
    //getGres();
 
@@ -265,7 +265,7 @@ void IMU::getTempAdc(int16_t *t){
   uint8_t buf[2];  
   I2C_Read_NBytes(SH200I_ADDRESS,SH200I_OUTPUT_TEMP,2,buf);
 
-  *t=((uint16_t)buf[1]<<8)|buf[0];  
+  *t=(int16_t)((buf[1]<<8)|buf[0]);  
 }
 
 void IMU::getTempData(float *t){

--- a/src/IMU.cpp
+++ b/src/IMU.cpp
@@ -273,5 +273,5 @@ void IMU::getTempData(float *t){
   uint8_t buf[2];  
   I2C_Read_NBytes(SH200I_ADDRESS,SH200I_OUTPUT_TEMP,2,buf);
 
-  *t=((uint16_t)buf[1]<<8)|buf[0];  
+  *t=(float)((buf[1]<<8)|buf[0]) / 333.87 + 21.0;
 }


### PR DESCRIPTION
Values of accel/gyro from IMU(SH200Q) do not change to a negative value because of wrong cast.
And example of SH200Q(SH200I?) looks old and each units were reversed.

fix #23