### PR TITLE
Fix for Wire in RTC to avoid crash when using Arduino on PlatformIO

### DIFF
--- a/src/M5StickC.cpp
+++ b/src/M5StickC.cpp
@@ -34,6 +34,8 @@ void M5StickC::begin(bool LCDEnable, bool PowerEnable, bool SerialEnable){
 	if (SerialEnable) {
 		Serial.println("OK");
 	}
+
+	Rtc.begin();
 }
 
 void M5StickC::update() {

--- a/src/RTC.cpp
+++ b/src/RTC.cpp
@@ -3,7 +3,11 @@
 
 
 RTC::RTC(){
-  Wire1.begin(21,22);  
+
+}
+
+void RTC::begin(void) {
+   Wire1.begin(21,22);   
 }
 
 void RTC::GetBm8563Time(void){

--- a/src/RTC.h
+++ b/src/RTC.h
@@ -22,6 +22,8 @@ typedef struct
 class RTC { 
 public:
   RTC();
+
+  void begin(void);
   void GetBm8563Time(void);
 
   void SetTime(RTC_TimeTypeDef* RTC_TimeStruct);


### PR DESCRIPTION
In RTC the Wire (i2c) initialization has been moved to specific begin() method to remove it from the RTC constructor.

This fixes the crashes when using the M5StickC library in an Arduino project but on PlatformIO.