### PR TITLE
Fix compile warning

### DIFF
--- a/src/AXP192.cpp
+++ b/src/AXP192.cpp
@@ -463,7 +463,6 @@ void AXP192::SetSleep(void){
 
 uint8_t AXP192::GetWarningLeve(void){
 
-    uint16_t vaps = 0;
     Wire1.beginTransmission(0x34);
     Wire1.write(0x47);
     Wire1.endTransmission();

--- a/src/M5Display.cpp
+++ b/src/M5Display.cpp
@@ -84,8 +84,6 @@ if(hzkTypes == InternalHzk16){
 bool M5Display::initHzk16(boolean use, const char *HZK16Path,
                         const char *ASC16Path) {
 
-  bool result = false;
-
   if (use == false) { // Do not use HZK16 and ASC16 fonts
 
     hzk16Type = DontUsedHzk16;

--- a/src/utility/qrcode.c
+++ b/src/utility/qrcode.c
@@ -853,7 +853,7 @@ int8_t qrcode_initText(QRCode *qrcode, uint8_t *modules, uint8_t version, uint8_
 }
 
 bool qrcode_getModule(QRCode *qrcode, uint8_t x, uint8_t y) {
-    if (x < 0 || x >= qrcode->size || y < 0 || y >= qrcode->size) {
+    if (x >= qrcode->size || y >= qrcode->size) {
         return false;
     }
 


### PR DESCRIPTION
```
\Arduino\libraries\M5StickC\src\AXP192.cpp: In member function 'uint8_t AXP192::GetWarningLeve()':
\Arduino\libraries\M5StickC\src\AXP192.cpp:466:14: warning: unused variable 'vaps' [-Wunused-variable]
     uint16_t vaps = 0;
              ^

\Arduino\libraries\M5StickC\src\M5Display.cpp: In member function 'bool M5Display::initHzk16(boolean, const char*, const char*)':
\Arduino\libraries\M5StickC\src\M5Display.cpp:87:8: warning: unused variable 'result' [-Wunused-variable]
   bool result = false;
        ^
```
->unused variable

```
\Arduino\libraries\M5StickC\src\utility\qrcode.c: In function 'qrcode_getModule':
\Arduino\libraries\M5StickC\src\utility\qrcode.c:856:11: warning: comparison is always false due to limited range of data type [-Wtype-limits]
     if (x < 0 || x >= qrcode->size || y < 0 || y >= qrcode->size) {
           ^

\Arduino\libraries\M5StickC\src\utility\qrcode.c:856:41: warning: comparison is always false due to limited range of data type [-Wtype-limits]
     if (x < 0 || x >= qrcode->size || y < 0 || y >= qrcode->size) {
                                         ^
```
-> x and y is uint8_t. Always positive.