### PR TITLE
Add AXP192 wake check

### DIFF
--- a/src/AXP192.cpp
+++ b/src/AXP192.cpp
@@ -461,6 +461,18 @@ void AXP192::SetSleep(void){
 
 }
 
+bool AXP192::GetSleep(void){
+
+    Wire1.beginTransmission(0x34);
+    Wire1.write(0x12);
+    Wire1.endTransmission();
+    Wire1.requestFrom(0x34, 1);
+    uint8_t buf = Wire1.read();
+    
+    return buf == 0x01;
+
+}
+
 uint8_t AXP192::GetWarningLeve(void){
 
     Wire1.beginTransmission(0x34);

--- a/src/AXP192.h
+++ b/src/AXP192.h
@@ -44,6 +44,7 @@ public:
   uint8_t GetBtnPress(void);
   
   void SetSleep(void);
+  bool GetSleep(void);
   
   // -- sleep
   void DeepSleep(uint64_t time_in_us = 0);


### PR DESCRIPTION
I want to get AXP WAKE.

```c
#include <M5StickC.h>

void setup() {
  M5.begin();
  M5.axp.SetSleep();
}

void loop() {
  Serial.println(M5.axp.GetSleep());
  delay(1000);
}
```

Returns true because it is sleeping.
Pressing the power button will wake and return false.