### PR TITLE
Add AXP halt

### DIFF
--- a/src/AXP192.cpp
+++ b/src/AXP192.cpp
@@ -515,3 +515,15 @@ uint8_t AXP192::GetBtnPress() {
     return state;
 }
 
+void AXP192::halt(){
+    Wire1.beginTransmission(0x34);
+    Wire1.write(0x32);
+    Wire1.endTransmission();
+    Wire1.requestFrom(0x34, 1);
+    uint8_t buf = Wire1.read();
+
+    Wire1.beginTransmission(0x34);
+    Wire1.write(0x32);
+    Wire1.write(buf | 0x80); // halt bit
+    Wire1.endTransmission();
+}

--- a/src/AXP192.h
+++ b/src/AXP192.h
@@ -50,6 +50,8 @@ public:
   void LightSleep(uint64_t time_in_us = 0);
 
   uint8_t GetWarningLeve(void);
+
+  void halt(void);
 public:
 private:
    


### PR DESCRIPTION
I want a power off function.

```c
#include <M5StickC.h>

void setup() {
  M5.begin();
  M5.Lcd.fillScreen(BLACK);
  M5.Lcd.println("HALT Test");

  Serial.print("run");
}

void loop() {
  M5.update();

  // halt
  if(M5.BtnA.wasReleased() || M5.Axp.GetWarningLeve()){
    M5.Axp.halt();
  }

  Serial.print(".");
  delay(100);
}
```