### PR TITLE
MahonyAHRS warning ignored

### DIFF
--- a/src/utility/MahonyAHRS.cpp
+++ b/src/utility/MahonyAHRS.cpp
@@ -241,9 +241,11 @@ void MahonyAHRSupdateIMU(float gx, float gy, float gz, float ax, float ay, float
 float invSqrt(float x) {
 	float halfx = 0.5f * x;
 	float y = x;
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
 	long i = *(long*)&y;
 	i = 0x5f3759df - (i>>1);
 	y = *(float*)&i;
+#pragma GCC diagnostic warning "-Wstrict-aliasing"
 	y = y * (1.5f - (halfx * y * y));
 	return y;
 }


### PR DESCRIPTION
```
\Arduino\libraries\M5StickC\src\utility\MahonyAHRS.cpp: In function 'float invSqrt(float)':
\Arduino\libraries\M5StickC\src\utility\MahonyAHRS.cpp:244:20: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
  long i = *(long*)&y;
                    ^

\Arduino\libraries\M5StickC\src\utility\MahonyAHRS.cpp:246:16: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
  y = *(float*)&i;
                ^
```