### PR TITLE
GFXfont: change type of first and last struct members to uint16_t

### DIFF
--- a/src/Fonts/GFXFF/gfxfont.h
+++ b/src/Fonts/GFXFF/gfxfont.h
@@ -21,7 +21,7 @@ typedef struct { // Data stored PER GLYPH
 typedef struct { // Data stored for FONT AS A WHOLE:
 	uint8_t  *bitmap;      // Glyph bitmaps, concatenated
 	GFXglyph *glyph;       // Glyph array
-	uint8_t   first, last; // ASCII extents
+	uint16_t  first, last; // ASCII extents
 	uint8_t   yAdvance;    // Newline distance (y axis)
 } GFXfont;
 


### PR DESCRIPTION
These struct members are accessed via pgm_read_word(), which is used with 16-bit data types. The current declaration as uint8_t causes incorrect values to be retrieved, which may lead to software crashes or lockups.