### PR TITLE
Add init code to RTC

### DIFF
--- a/src/RTC.cpp
+++ b/src/RTC.cpp
@@ -7,7 +7,12 @@ RTC::RTC(){
 }
 
 void RTC::begin(void) {
-   Wire1.begin(21,22);   
+  Wire1.begin(21,22);
+
+  Wire1.beginTransmission(0x51);
+  Wire1.write(0x00);
+  Wire1.write(0x00);
+  Wire1.endTransmission();
 }
 
 void RTC::GetBm8563Time(void){


### PR DESCRIPTION
I met register at 0x00 is value=0xA8.
I don't know why value was set 0xA8.
But to initialize it is fix this problem, and it is better manner.

ref: https://gist.github.com/takeru/8fc956301ac52d7f2eab2ca376e402f5
