### PR TITLE
Add deprecated, AXP192::GetWarningLeve()

### DIFF
--- a/src/AXP192.h
+++ b/src/AXP192.h
@@ -41,7 +41,7 @@ public:
 	void SetSleep(void);
 	void DeepSleep(uint64_t time_in_us = 0);
 	void LightSleep(uint64_t time_in_us = 0);
-  	uint8_t GetWarningLeve(void);
+  	uint8_t GetWarningLeve(void) __attribute__((deprecated));
 
 public:
 	// void SetChargeVoltage( uint8_t );


### PR DESCRIPTION
We should use GetWarningLevel.
Therefore, GetWarningLeve is deprecated.