### PR TITLE
fix-DeepSleep

### DIFF
--- a/src/AXP192.cpp
+++ b/src/AXP192.cpp
@@ -306,8 +306,7 @@ void AXP192::SetSleep(void)
     buf = (1<<3)|buf;
 	Write1Byte( 0x31 , buf );
 	Write1Byte( 0x90 , 0x00 );
-	Write1Byte( 0x12 , 0x09 );
-    Write1Byte( 0x12 , 0x00 );
+	Write1Byte( 0x12 , 0x01 );
 }
 
 uint8_t AXP192::GetWarningLeve(void)


### PR DESCRIPTION
`Write1Byte( 0x12 , 0x00 );` is shutdown 3.3V to ESP32.
DeepSleep(time_in_us) didn't wakeup after time_in_us.
