### PR TITLE
Fix AXP192 Comment(GPIO0 -> RTC to MIC)

### DIFF
--- a/src/AXP192.cpp
+++ b/src/AXP192.cpp
@@ -29,7 +29,7 @@ void AXP192::begin(void)
     // 128ms power on, 4s power off
     Write1Byte(0x36, 0x0C);
 
-    // Set RTC voltage to 3.3V
+    // Set MIC voltage to 3.3V
     Write1Byte(0x91, 0xF0);	
 
     // Set GPIO0 to LDO


### PR DESCRIPTION
# 0x91 is GPIO0(MIC)
![91](https://user-images.githubusercontent.com/10301363/68924423-27be7880-07c4-11ea-9da6-52d27a729ac9.png)

LDO1 : RTC
GPIO0 : MIC