### PR TITLE
AXP192: Add posisbility to keep LDO2&LDO3 disabled in begin(...)

### DIFF
--- a/src/AXP192.cpp
+++ b/src/AXP192.cpp
@@ -13,6 +13,9 @@ void AXP192::begin(bool disableLDO2, bool disableLDO3, bool disableRTC, bool dis
     // Set LDO2 & LDO3(TFT_LED & TFT) 3.0V
     Write1Byte(0x28, 0xcc);	
 
+    // Set ADC sample rate to 200hz
+    Write1Byte(0x84, 0b11110010);
+    
     // Set ADC to All Enable
     Write1Byte(0x82, 0xff);
 
@@ -309,10 +312,10 @@ uint16_t AXP192::GetVapsData(void)
 
 void AXP192::SetSleep(void)
 {
-    Write1Byte(0x31 , Read8bit(0x31) | ( 1 << 3));
-    Write1Byte(0x90 , Read8bit(0x90) | 0x07);
-    Write1Byte(0x82, 0x00);
-    Write1Byte(0x12, Read8bit(0x12) & 0xA1);
+    Write1Byte(0x31 , Read8bit(0x31) | ( 1 << 3)); // Power off voltag 3.0v
+    Write1Byte(0x90 , Read8bit(0x90) | 0x07); // GPIO1 floating
+    Write1Byte(0x82, 0x00); // Disable ADCs
+    Write1Byte(0x12, Read8bit(0x12) & 0xA1); // Disable all outputs but DCDC1
 }
 
 uint8_t AXP192::GetWarningLeve(void)
@@ -499,4 +502,9 @@ void AXP192::SetChargeCurrent(uint8_t current)
 void AXP192::PowerOff()
 {
     Write1Byte(0x32, Read8bit(0x32) | 0x80);
+}
+
+void AXP192::setAdcState(bool state)
+{
+        Write1Byte(0x82, state ? 0xff : 0x00);
 }

--- a/src/AXP192.cpp
+++ b/src/AXP192.cpp
@@ -5,7 +5,7 @@ AXP192::AXP192()
   
 }
 
-void AXP192::begin(void)
+void AXP192::begin(bool disableLDO2, bool disableLDO3)
 {  
     Wire1.begin(21, 22);
     Wire1.setClock(400000);
@@ -24,7 +24,10 @@ void AXP192::begin(void)
 
     // Enable Ext, LDO2, LDO3, DCDC1
     // Close DCDC2 output
-    Write1Byte(0x12, (Read8bit(0x12) & 0xef) | 0x4D);	
+    byte buf = (Read8bit(0x12) & 0xef) | 0x4D;
+    if(disableLDO3) buf &= ~(1<<3);
+    if(disableLDO2) buf &= ~(1<<2);
+    Write1Byte(0x12, buf);	
     
     // 128ms power on, 4s power off
     Write1Byte(0x36, 0x0C);

--- a/src/AXP192.cpp
+++ b/src/AXP192.cpp
@@ -504,7 +504,7 @@ void AXP192::PowerOff()
     Write1Byte(0x32, Read8bit(0x32) | 0x80);
 }
 
-void AXP192::setAdcState(bool state)
+void AXP192::SetAdcState(bool state)
 {
-        Write1Byte(0x82, state ? 0xff : 0x00);
+    Write1Byte(0x82, state ? 0xff : 0x00);
 }

--- a/src/AXP192.h
+++ b/src/AXP192.h
@@ -21,7 +21,14 @@
 class AXP192 {
 public:
     AXP192();
-    void  begin(bool disableLDO2 = false, bool disableLDO3 = false);
+    /**
+     * LDO2: Display backlight
+     * LDO3: Display Control
+     * RTC: Don't set GPIO1 as LDO
+     * DCDC1: Main rail. When not set the controller shuts down.
+     * DCDC3: Use unknown
+     */
+    void  begin(bool disableLDO2 = false, bool disableLDO3 = false, bool disableRTC = false, bool disableDCDC1 = false, bool disableDCDC3 = false);
     void  ScreenBreath(uint8_t brightness);
     bool  GetBatState();
   

--- a/src/AXP192.h
+++ b/src/AXP192.h
@@ -78,6 +78,8 @@ public:
     void SetLDO2( bool State );
     void SetLDO3( bool State );
     void PowerOff();
+
+    void setAdcState(bool State);
     
 private:
     void Write1Byte( uint8_t Addr ,  uint8_t Data );

--- a/src/AXP192.h
+++ b/src/AXP192.h
@@ -77,9 +77,10 @@ public:
     void SetCoulombClear();
     void SetLDO2( bool State );
     void SetLDO3( bool State );
+    void SetAdcState(bool State);
+    
     void PowerOff();
 
-    void setAdcState(bool State);
     
 private:
     void Write1Byte( uint8_t Addr ,  uint8_t Data );

--- a/src/AXP192.h
+++ b/src/AXP192.h
@@ -21,7 +21,7 @@
 class AXP192 {
 public:
     AXP192();
-    void  begin(void);
+    void  begin(bool disableLDO2 = false, bool disableLDO3 = false);
     void  ScreenBreath(uint8_t brightness);
     bool  GetBatState();
   


### PR DESCRIPTION
This is to prevent the screen from flickering in Axp.begin(), when directly afterwards calling Axp.SetLDO2(false) and Axp.SetLDO3(false).

The two parameters are with default values which keep the existing behaviour, so no change in existing code.