### PR TITLE
AXP192: Fixed integer underflow in GetCoulombData()

### DIFF
--- a/src/AXP192.cpp
+++ b/src/AXP192.cpp
@@ -214,7 +214,7 @@ float AXP192::GetCoulombData(void)
 
   //c = 65536 * current_LSB * (coin - coout) / 3600 / ADC rate
   //Adc rate can be read from 84H ,change this variable if you change the ADC reate
-  float ccc = 65536 * 0.5 * (coin - coout) / 3600.0 / 25.0;
+  float ccc = 65536 * 0.5 * (int32_t(coin - coout)) / 3600.0 / 25.0;
   return ccc;
 
 }


### PR DESCRIPTION
When coout is bigger than coin, an unsigned underflow occurs before
conversion to float. Bounds checking may be required, or may be
omitted with real battery parameters. Documentation is not available.