### PR TITLE
For BROKEN LCD

### DIFF
--- a/examples/Basics/FactoryTest/FactoryTest.ino
+++ b/examples/Basics/FactoryTest/FactoryTest.ino
@@ -88,6 +88,7 @@ void IRAM_ATTR onTimer()
 
 void ErrorMeg(uint8_t code, const char *str)
 {
+    printf("ErrorMeg: code=%02X str=%s\n", code, str);
     Disbuff.fillRect(0, 0, 160, 80, BLACK);
     Disbuff.pushImage(0, 16, 48, 48, (uint16_t *)error_48);
     Disbuff.setCursor(100, 10);
@@ -104,6 +105,7 @@ void ErrorMeg(uint8_t code, const char *str)
 
 void ErrorMeg(uint8_t code, const char *str1, const char *str2)
 {
+    printf("ErrorMeg: code=%02X str1=%s str2=%s\n", code, str1, str2);
     Disbuff.fillRect(0, 0, 160, 80, BLACK);
     Disbuff.pushImage(0, 16, 48, 48, (uint16_t *)error_48);
     Disbuff.setCursor(100, 10);


### PR DESCRIPTION
But maybe AXP is broken.


```
04:18:31.348 -> M5StickC initializing...OK
04:18:32.769 -> FUCK STC
04:18:33.543 -> [D][FreeRTOS.cpp:189] take(): Semaphore taking: name: RegisterAppEvt (0x3ffe895c), owner: <N/A> for registerApp
04:18:33.577 -> [D][FreeRTOS.cpp:198] take(): Semaphore taken:  name: RegisterAppEvt (0x3ffe895c), owner: registerApp
04:18:33.577 -> [D][BLEDevice.cpp:108] gattServerEventHandler(): gattServerEventHandler [esp_gatt_if: 4] ... Unknown
04:18:33.577 -> [D][FreeRTOS.cpp:189] take(): Semaphore taking: name: CreateEvt (0x3ffe8ba0), owner: <N/A> for createService
04:18:33.577 -> [D][FreeRTOS.cpp:198] take(): Semaphore taken:  name: CreateEvt (0x3ffe8ba0), owner: createService
04:18:33.613 -> [D][FreeRTOS.cpp:189] take(): Semaphore taking: name: CreateEvt (0x3ffe8e04), owner: <N/A> for executeCreate
04:18:33.613 -> [D][FreeRTOS.cpp:198] take(): Semaphore taken:  name: CreateEvt (0x3ffe8e04), owner: executeCreate
04:18:33.613 -> [D][BLEDevice.cpp:108] gattServerEventHandler(): gattServerEventHandler [esp_gatt_if: 4] ... Unknown
04:18:33.613 -> [D][BLEService.cpp:225] addCharacteristic(): Adding characteristic: uuid=1bc68da0-f3e3-11e9-81b4-2a2ae2dbcc to service: UUID: 1bc68b2a-f3e3-11e9-81b4-2a2ae2dbcc, handle: 0x0028
04:18:33.646 -> [D][BLEService.cpp:225] addCharacteristic(): Adding characteristic: uuid=1bc68efe-f3e3-11e9-81b4-2a2ae2dbcc to service: UUID: 1bc68b2a-f3e3-11e9-81b4-2a2ae2dbcc, handle: 0x0028
04:18:33.646 -> ErrorMeg code=21 str=AXP find error
```