### PR TITLE
Add SetGPIO0 method to configure output to microphone

### DIFF
--- a/src/AXP192.cpp
+++ b/src/AXP192.cpp
@@ -523,6 +523,21 @@ void AXP192::SetLDO3(bool State)
     Write1Byte( 0x12 , buf );
 }
 
+void AXP192::SetGPIO0(bool State)
+{
+    uint8_t buf = Read8bit(0x90);
+    if ( State == true )
+    {
+        buf &= ~(0x07); // clear last 3 bits
+        buf |= 0x02;    // set as LDO
+    }
+    else
+    {
+        buf |= 0x07;    // set as floating
+    }
+    Write1Byte( 0x90 , buf );
+}
+
 // Not recommend to set charge current > 100mA, since Battery is only 80mAh.
 // more then 1C charge-rate may shorten battery life-span.
 void AXP192::SetChargeCurrent(uint8_t current)

--- a/src/AXP192.h
+++ b/src/AXP192.h
@@ -80,6 +80,7 @@ public:
     void SetCoulombClear()  __attribute__((deprecated)); // use ClearCoulombcounter instead
     void SetLDO2( bool State );     // Can turn LCD Backlight OFF for power saving
     void SetLDO3( bool State );
+    void SetGPIO0( bool State );
     void SetAdcState(bool State);
     
     // -- Power Off


### PR DESCRIPTION
Implement method for AXP192 to modify GPIO0 configuration.
Tested on microphone demo code:
Calling `M5.Axp.SetGPIO0(false)` disables power to microphone.
Calling `M5.Axp.SetGPIO0(true)` enables power to microphone.

Attached table from datasheet for reference:
![image](https://user-images.githubusercontent.com/23294131/82135924-b88d1400-983a-11ea-8b60-5991560f735c.png)
