### PR TITLE
Fix BtnIrq.ino example

### DIFF
--- a/examples/Advanced/AXP192/BtnIrq/BtnIrq.ino
+++ b/examples/Advanced/AXP192/BtnIrq/BtnIrq.ino
@@ -57,8 +57,10 @@ void setup() {
 void loop() {
   delay(1000);
   M5.Lcd.setCursor(0, 0);
-  M5.Lcd.printf("pin 35 status: %d\r\n", digitalRead(35));
-  M5.Lcd.printf("axp192 btn status: %d\r\n", axp192_getBtnIRQStatus());
-  Serial.printf("pin 35 status: %d\r\n", digitalRead(35));
-  Serial.printf("axp192 btn status: %d\r\n", axp192_getBtnIRQStatus());
+  uint8_t PinStatus = digitalRead(35);
+  uint8_t IRQStatus = axp192_getBtnIRQStatus();
+  M5.Lcd.printf("pin 35 status: %d\r\n", PinStatus);
+  M5.Lcd.printf("axp192 btn status: %d\r\n", IRQStatus);
+  Serial.printf("pin 35 status: %d\r\n", PinStatus);
+  Serial.printf("axp192 btn status: %d\r\n", IRQStatus);
 }


### PR DESCRIPTION
In the original, I got the following the serial output, but the readings on the LCD screen was fine (they change as expected)
```
16:46:30.071 -> pin 35 status: 1
16:46:30.071 -> axp192 btn status: 0
16:46:31.092 -> pin 35 status: 1
16:46:31.092 -> axp192 btn status: 0
```

```
  M5.Lcd.printf("pin 35 status: %d\r\n", digitalRead(35));
  // Read IRQStatus, also clears the status bits
  M5.Lcd.printf("axp192 btn status: %d\r\n", axp192_getBtnIRQStatus());
  // IRQStatus has been cleared, so pin 35 is always 1
  Serial.printf("pin 35 status: %d\r\n", digitalRead(35));
  // Read IRQStatus again but since it's been cleared, it's always 0
  Serial.printf("axp192 btn status: %d\r\n", axp192_getBtnIRQStatus());
```

The updates in this PR should fix this and both Serial and LCD will reflect the changing values. 