### PR TITLE
Fix quotation mark not being correct

### DIFF
--- a/src/M5StickC.h
+++ b/src/M5StickC.h
@@ -123,7 +123,7 @@ extern M5StickC M5;
 #define sh200q Sh200Q
 
 #else
-#error “This library only supports boards with ESP32 processor.”	
+#error "This library only supports boards with ESP32 processor.”	
 #endif
 
 #endif

--- a/src/M5StickC.h
+++ b/src/M5StickC.h
@@ -123,7 +123,7 @@ extern M5StickC M5;
 #define sh200q Sh200Q
 
 #else
-#error "This library only supports boards with ESP32 processor.”	
+#error "This library only supports boards with ESP32 processor."	
 #endif
 
 #endif


### PR DESCRIPTION
This causes cppcheck to throw `The code contains unhandled character(s) (character code=226). Neither unicode nor extended ascii is supported.`