### PR TITLE
changed the name of min macro to resolve conflicts with STL

### DIFF
--- a/src/utility/In_eSPI.h
+++ b/src/utility/In_eSPI.h
@@ -538,9 +538,9 @@
 template <typename T> static inline void
 swap_coord(T& a, T& b) { T t = a; a = b; b = t; }
 
-#ifndef min
+#ifndef espi_min
   // Return minimum of two numbers, may already be defined
-  #define min(a,b) (((a) < (b)) ? (a) : (b))
+  #define espi_min(a,b) (((a) < (b)) ? (a) : (b))
 #endif
 
 // This structure allows sketches to retrieve the user setup parameters at runtime


### PR DESCRIPTION
Thank you for the M5StickC library. It's very helpful for my development.

As the issues #132 #103 describe, compilation errors occur when using `<bitset>` or `<sstream>`, etc.
They are caused by the name conflict between these two:
- "min" macro in In_eSPI.h
- STL std::min function

It can be solved by including STL headers before <M5StickC.h>, but the min macro is unused anywhere in the M5StickC library, so it seems to be better to change the name of macro.

In my local test, program with bitset or sstream was successfully compiled.